### PR TITLE
refactor: inputs styles

### DIFF
--- a/packages/frontend/src/components/AttachmentsList/style.ts
+++ b/packages/frontend/src/components/AttachmentsList/style.ts
@@ -3,7 +3,8 @@ import { createStyles } from '@mantine/core'
 const useStyles = createStyles((theme) => ({
   attachmentHeader: {
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    padding: '10px 0'
   },
   title: {
     color: theme.colors.gray[2],

--- a/packages/frontend/src/components/Task/style.ts
+++ b/packages/frontend/src/components/Task/style.ts
@@ -28,7 +28,8 @@ const useStyles = createStyles((theme) => ({
   input: {
     color: theme.colors.gray[3],
     borderRadius: theme.radius.md,
-    width: '100%'
+    width: '100%',
+    margin: '0.6rem 0'
   },
   buttonSave: {
     marginLeft: 'auto'


### PR DESCRIPTION
Add margin to inputs in dashboard. Text was overlapping another parts. Same change on Greybutton in attachements section(but with padding).